### PR TITLE
Do a PHP version check and use correct call for debug_backtrace()

### DIFF
--- a/Lib/CakeResque.php
+++ b/Lib/CakeResque.php
@@ -50,21 +50,28 @@ class CakeResque
  * @param  boolean 	$trackStatus Whether to track the status of the job
  * @return void
  */
-	public static function enqueue($queue, $class, $args = array(), $trackStatus = false) {
-		$r = Resque::enqueue($queue, $class, $args, $trackStatus);
+  public static function enqueue($queue, $class, $args = array(), $trackStatus = false) {
+    $r = Resque::enqueue($queue, $class, $args, $trackStatus);
 
-		if (!is_array($args)) {
-			$args = array($args);
-		}
-		self::$logs[$queue][] = array(
-			'queue' => $queue,
-			'class' => $class,
-			'method' => array_shift($args),
-			'args' => $args,
-			'jobId' => $r,
-			'caller' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)
-		);
+    if (!is_array($args)) {
+      $args = array($args);
+    }
 
-		return $r;
-	}
+    // two-argument form of debug_backtrace() is only available in PHP >= 5.4.0
+    if(version_compare(PHP_VERSION, '5.4.0') >= 0) {
+      $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+    } else {
+      $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+    }
+    self::$logs[$queue][] = array(
+      'queue' => $queue,
+      'class' => $class,
+      'method' => array_shift($args),
+      'args' => $args,
+      'jobId' => $r,
+      'caller' => $caller
+    );
+
+    return $r;
+  }
 }


### PR DESCRIPTION
Do a PHP version check and use the appropriate form of debug_backtrace() depending on PHP version. Two-argument format of debug_backtrace() is only available in PHP >= 5.4.0
