### PR TITLE
Update CakeResqueBootstrap.php to use Cake 2.x 2.x magic (a.k.a. use ShellDispatcher).

### DIFF
--- a/Lib/CakeResqueBootstrap.php
+++ b/Lib/CakeResqueBootstrap.php
@@ -19,62 +19,33 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-/*
- * Copy/Paste from lib/Cake/Console/cake.php
+/**
+ * Copy/Paste from lib/Cake/Console/cake.php, except /lib path calculation.
  */
-if (!defined('DS')) {
-	define('DS', DIRECTORY_SEPARATOR);
-}
-
-$dispatcher = getenv('CAKE') . 'Console' . DS . 'ShellDispatcher.php';
+$ds = DIRECTORY_SEPARATOR;
+$dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
 $found = false;
 $paths = explode(PATH_SEPARATOR, ini_get('include_path'));
 
 foreach ($paths as $path) {
-	if (file_exists($path . DS . $dispatcher)) {
+	if (file_exists($path . $ds . $dispatcher)) {
 		$found = $path;
+		break;
 	}
 }
 
-if (!$found && function_exists('ini_set')) {
-	$root = dirname(dirname(dirname(__FILE__)));
-	ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . dirname(getenv('CAKE')));
-}
-
-if (!require_once ($dispatcher)) {
-	trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
+if (!$found) {
+	$root = dirname(dirname(dirname(dirname(__DIR__))));
+	if (!include $root . $ds . 'lib' . $ds . $dispatcher) {
+		trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
+	}
+} else {
+	include $found . $ds . $dispatcher;
 }
 
 unset($paths, $path, $found, $dispatcher, $root, $ds);
 
-/*
- * Copy/Paste from  lib/Cake/Console/ShellDipatcher::_bootstrap()
- */
-define('ROOT', dirname(dirname(getenv('CAKE'))));
-if (!defined('APP_DIR')) {
-	define('APP_DIR', basename(dirname(dirname(dirname(dirname(__FILE__))))));
-}
-define('APP', ROOT . DS . APP_DIR . DS);
-define('WWW_ROOT', APP . 'webroot' . DS);
-if (!is_dir(ROOT . DS . APP_DIR . DS . 'tmp')) {
-	define('TMP', CAKE_CORE_INCLUDE_PATH . DS . 'Cake' . DS . 'Console' . DS . 'Templates' . DS . 'skel' . DS . 'tmp' . DS);
-}
-$boot = file_exists(ROOT . DS . APP_DIR . DS . 'Config' . DS . 'bootstrap.php');
-require getenv('CAKE') . DS . 'bootstrap.php';
-
-if (!file_exists(APP . 'Config' . DS . 'core.php')) {
-	include_once CAKE_CORE_INCLUDE_PATH . DS . 'Cake' . DS . 'Console' . DS . 'Templates' . DS . 'skel' . DS . 'Config' . DS . 'core.php';
-	App::build();
-}
-require_once CAKE . 'Console' . DS . 'ConsoleErrorHandler.php';
-$ErrorHandler = new ConsoleErrorHandler();
-set_exception_handler(array($ErrorHandler, 'handleException'));
-set_error_handler(array($ErrorHandler, 'handleError'), Configure::read('Error.level'));
-
-if (!defined('FULL_BASE_URL')) {
-	define('FULL_BASE_URL', 'http://localhost');
-}
-
-require __DIR__ . DS . 'Resque_Job_Creator.php';
-
+new ShellDispatcher($argv);
 App::uses('Shell', 'Console');
+
+App::uses('Resque_Job_Creator', 'CakeResque.Lib');

--- a/Test/Case/Lib/Resque_Job_CreatorTest.php
+++ b/Test/Case/Lib/Resque_Job_CreatorTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Test class for Resque_Job_Creator
  *
@@ -28,8 +27,7 @@ App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
 App::uses('Resque_Job_Creator', 'CakeResque.Lib');
 
-class Resque_Job_CreatorTest extends CakeTestCase
-{
+class Resque_Job_CreatorTest extends CakeTestCase {
 
 /**
  * Path to the temporary directory for temporary files
@@ -68,8 +66,8 @@ class Resque_Job_CreatorTest extends CakeTestCase
  * Removing all temporary files created for testing
  */
 	public static function cleanTempDir() {
-		$folder = new Folder();
-		$folder->delete(self::$testDir);
+		$Folder = new Folder();
+		$Folder->delete(self::$testDir);
 	}
 
 /**


### PR DESCRIPTION
CakeResqueBootstrap.php is quite old and carries 1.3 bits.

This approach, loads and instantiates the core's ShellDispatcher (replicating the logic inside lib/Cake/Console/cake.php), without actually calling ShellDispatcher::run(), with the benefit of using the actual logic to init all constants, handlers and environments.

Also, App class magic can be later used to load other classes.
