### PR TITLE
Allow configurable vendor path for Composer packages

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -88,6 +88,17 @@
 			)
 		)
 		*/
+		'Vendor' => array(
+			// If the CakeResque plugin was added directly or as a submodule, the dependencies
+			// were installed internally in /Plugin/CakeResque/vendor by Composer.
+			'path' => App::pluginPath('CakeResque') . 'vendor'
+
+			// If the CakeResque plugin AND dependencies were installed using Composer, everything
+			// was installed in the standard Composer location /Vendor. The CakeResque plugin
+			// is still installed in /Plugin/CakeResque but does not have an internal /vendor
+			// folder for the dependencies.
+			// 'path' => APP . 'Vendor'
+		),
 		'Resque' => array(
 
 			// Path to the php-resque library

--- a/Console/Command/CakeResqueShell.php
+++ b/Console/Command/CakeResqueShell.php
@@ -60,13 +60,13 @@ class CakeResqueShell extends Shell {
 		if (substr(Configure::read('CakeResque.Resque.lib'), 0, 1) === '/') {
 			$this->_resqueLibrary = Configure::read('CakeResque.Resque.lib') . DS;
 		} else {
-			$this->_resqueLibrary = realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Resque.lib')) . DS;
+			$this->_resqueLibrary = realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Resque.lib')) . DS;
 		}
 
 		if (substr(Configure::read('CakeResque.Scheduler.lib'), 0, 1) === '/') {
 			$this->_ResqueSchedulerLibrary = Configure::read('CakeResque.Scheduler.lib') . DS;
 		} else {
-			$this->_ResqueSchedulerLibrary = realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Scheduler.lib')) . DS;
+			$this->_ResqueSchedulerLibrary = realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Scheduler.lib')) . DS;
 		}
 
 		$this->ResqueStatus = new ResqueStatus\ResqueStatus(Resque::Redis());

--- a/Lib/CakeResque.php
+++ b/Lib/CakeResque.php
@@ -23,8 +23,8 @@ if (substr(Configure::read('CakeResque.Resque.lib'), 0, 1) === '/') {
 	require_once Configure::read('CakeResque.Resque.lib') . DS . 'lib' . DS . 'Resque.php';
 	require_once Configure::read('CakeResque.Resque.lib') . DS . 'lib' . DS . 'Resque' . DS . 'Worker.php';
 } else {
-	require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Resque.lib') . DS . 'lib' . DS . 'Resque.php');
-	require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Resque.lib') . DS . 'lib' . DS . 'Resque' . DS . 'Worker.php');
+	require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Resque.lib') . DS . 'lib' . DS . 'Resque.php');
+	require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Resque.lib') . DS . 'lib' . DS . 'Resque' . DS . 'Worker.php');
 }
 
 
@@ -33,12 +33,12 @@ if (substr(Configure::read('CakeResque.Scheduler.lib'), 0, 1) === '/') {
 	require_once Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'Stat.php';
 	require_once Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'Job' . DS . 'Status.php';
 } else {
-	require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'ResqueScheduler.php');
-	require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'Stat.php');
-	require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'Job' . DS . 'Status.php');
+	require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'ResqueScheduler.php');
+	require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'Stat.php');
+	require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . Configure::read('CakeResque.Scheduler.lib') . DS . 'lib' . DS . 'ResqueScheduler' . DS . 'Job' . DS . 'Status.php');
 }
 
-require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . 'kamisama' . DS . 'resque-status' . DS . 'src' . DS . 'ResqueStatus' . DS . 'ResqueStatus.php');
+require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . 'kamisama' . DS . 'resque-status' . DS . 'src' . DS . 'ResqueStatus' . DS . 'ResqueStatus.php');
 
 Resque::setBackend(
 	Configure::read('CakeResque.Redis.host') . ':' . Configure::read('CakeResque.Redis.port'),

--- a/Test/Case/Console/Command/CakeResqueShellTest.php
+++ b/Test/Case/Console/Command/CakeResqueShellTest.php
@@ -9,7 +9,7 @@ App::uses('ShellDispatcher', 'Console');
 App::uses('Shell', 'Console');
 App::uses('CakeResqueShell', 'CakeResque.Console/Command');
 
-require_once realpath(App::pluginPath('CakeResque') . 'vendor' . DS . 'autoload.php');
+require_once realpath(Configure::read('CakeResque.Vendor.path') . DS . 'autoload.php');
 
 class CakeResqueShellTest extends CakeTestCase {
 


### PR DESCRIPTION
The current install steps assume Composer is run inside the plugin folder and installs packages in /Plugin/CakeResque/vendor. This change allows you to also install the CakeResque plugin with Composer. The plugin and all its dependencies are installed in the default Composer location (/Vendor for CakePHP). The default behavior stays the same as it was before.
