### PR TITLE
add 'CakeResque.Status.lib' config option

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -207,5 +207,9 @@ $config['CakeResque'] = array(
 			'handler' => 'RotatingFile',
 			'target' => TMP . 'logs' . DS . 'resque-scheduler.log'
 		)
+	),
+	'Status' => array(
+		// Path to the resque-status library
+		'lib' => 'kamisama/resque-status',
 	)
 );

--- a/Lib/CakeResque.php
+++ b/Lib/CakeResque.php
@@ -56,7 +56,8 @@ class CakeResque {
 		if (
 			!($redis = Configure::read('CakeResque.Redis')) ||
 			!($resqueLib = Configure::read('CakeResque.Resque.lib')) ||
-			!($schedulerLib = Configure::read('CakeResque.Scheduler.lib'))
+			!($schedulerLib = Configure::read('CakeResque.Scheduler.lib')) ||
+			!($statusLib = Configure::read('CakeResque.Status.lib'))
 		) {
 			throw new ConfigureException(__d('cake_resque', 'There is an error in the configuration file.'));
 		}
@@ -82,12 +83,16 @@ class CakeResque {
 		}
 		$schedulerLib .= DS . 'lib' . DS . 'ResqueScheduler' . DS;
 
+		if (substr($statusLib, 0, 1) !== '/') {
+			$statusLib = $pluginVendorPath . $statusLib;
+		}
+
 		require_once realpath($resqueLib . 'Resque.php');
 		require_once realpath($resqueLib . 'Resque' . DS . 'Worker.php');
 		require_once realpath($schedulerLib . 'ResqueScheduler.php');
 		require_once realpath($schedulerLib . 'Stat.php');
 		require_once realpath($schedulerLib . 'Job' . DS . 'Status.php');
-		require_once realpath($pluginVendorPath . 'kamisama' . DS . 'resque-status' . DS . 'src' . DS . 'ResqueStatus' . DS . 'ResqueStatus.php');
+		require_once realpath($statusLib . DS . 'src' . DS . 'ResqueStatus' . DS . 'ResqueStatus.php');
 
 		Resque::setBackend($redis['host'] . ':' . $redis['port'], $redis['database'], $redis['namespace']);
 	}


### PR DESCRIPTION
It's already done correctly for the 'php-resque-ex' and 'php-resque-ex-scheduler' packages. I've just added the ability to specify a path to the 'resque-status' package via the configs, so it's consistent with the other two.

The reason I need it is because I'm using Composer to install the Cake-Resque plugin itself - not just its dependencies. So, Composer installs ALL dependent packages in /Vendors - not in the `CakePlugin::path('CakeResque') . 'vendor' . DS;` directory. So, I need to be able to specify the correct path to that via a config option.

You'll see in my comments that I've done a work around so as not to break things for existing users, but really I think this config option should probably be required in the next major version.

Also, on another note, I think the `$pluginVendorPath` itself should probably be configurable for the same reason - people using composer may have different vendor paths. However, I I haven't changed that in this PR.

FYI, my own custom bootstrap file looks like this:

```
$vendorPaths = App::path('Vendor');
$appVendorPath = $vendorPaths[0];
Configure::write('CakeResque.Resque.lib', $appVendorPath . 'kamisama' . DS . 'php-resque-ex');
Configure::write('CakeResque.Scheduler.lib', $appVendorPath . 'kamisama' . DS . 'php-resque-ex-scheduler');
Configure::write('CakeResque.Status.lib', $appVendorPath . 'kamisama' . DS . 'resque-status' );
```

Since I'm having composer install them with the exact same name but just at a different location, if there was a config option for the $pluginVendorPath then all I'd need to do is this:

```
$vendorPaths = App::path('Vendor');
$appVendorPath = $vendorPaths[0];
Configure::write('CakeResque.PluginVendorPath', $appVendorPath);
```

(of course, anyone using Composer to install their Cake plugins is in the same situation)

Signed-off-by: Joshua Paling joshua.paling@gmail.com
