### PR TITLE
streamline install guide

### DIFF
--- a/src/CakeResque/Pages/install.md
+++ b/src/CakeResque/Pages/install.md
@@ -61,7 +61,6 @@ CakePlugin::load(array( # or CakePlugin::loadAll(array(
 ~~~ .language-php
 public function perform() {
 	$this->initialize();
-	$this->loadTasks();
 	return $this->runCommand($this->args[0], $this->args);
 }
 ~~~
@@ -71,13 +70,10 @@ public function perform() {
 ~~~ .language-php
 <?php
 App::uses('AppModel', 'Model');
-class AppShell extends Shell
-{
-	public function perform()
-	{
+class AppShell extends Shell {
+	public function perform() {
 		$this->initialize();
-		$this->loadTasks();
-		$this->{array_shift($this->args)}();
+		return $this->runCommand($this->args[0], $this->args);
 	}
 }
 ~~~


### PR DESCRIPTION
Hi Kamisama,

we recently updated our cake-resque plugin and found some mismatches in the [installation-docs](http://cakeresque.kamisama.me/install#install):
- The perform-Method does not match the "Final AppShell.php" section
- The described "$this->loadTasks();" is done directly within the initialize-Method of Shell.php

Let me know if both of the described issues are fine for you! 
