### PR TITLE
Use custom console handler for stdout

### DIFF
--- a/Console/CakeResqueEchoConsoleOutput.php
+++ b/Console/CakeResqueEchoConsoleOutput.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Replacement for ConsoleOutput('php://stdout') which may cause troubles with
+ * more sophisticated process handling on unix.
+ *
+ * Simple uses `echo` to write the messages
+ */
+class CakeResqueEchoConsoleOutput extends ConsoleOutput {
+
+	/**
+	 * Override parent constructor as we don't deal with file handles directly
+	 */
+	public function __construct() {
+		if (DS === '\\' && !(bool)env('ANSICON')) {
+			$this->_outputAs = self::PLAIN;
+		}
+	}
+
+	/**
+	 * Override parent to not use the file handler (which we don't use)
+	 * @param string $message
+	 * @return bool
+	 */
+	protected function _write($message) {
+		echo $message;
+		return true;
+	}
+}

--- a/Console/Command/CakeResqueShell.php
+++ b/Console/Command/CakeResqueShell.php
@@ -60,6 +60,11 @@ class CakeResqueShell extends Shell {
  */
 	const VERSION = '4.1.0';
 
+	public function __construct() {
+		App::uses('CakeResqueEchoConsoleOutput', 'CakeResque.Console');
+		parent::__construct(new CakeResqueEchoConsoleOutput());
+	}
+
 /**
  * Startup callback.
  *


### PR DESCRIPTION
The original cake ConsoleHandler uses fopen('php://stdout') which deep
down uses the C call 'dup' to duplicate stdout. However this can lead
to a worker not returning the shell, e.g.

`ssh host .../cake CakeResque.CakeResque start --queue test`

would hang without this change.

Fixes kamisama/Cake-Resque#75

---

Using a custom ConsoleHandler which does not open directly `php://stdout` was the only way avoiding the `dup()` call causes the hang when trying to instrument starting workers via ssh.
