### PR TITLE
using APP constant for dir name

### DIFF
--- a/Lib/Resque_Job_Creator.php
+++ b/Lib/Resque_Job_Creator.php
@@ -39,7 +39,7 @@ class Resque_Job_Creator {
 		list($plugin, $model) = pluginSplit($className);
 
 		if (self::$rootFolder === null) {
-			self::$rootFolder = dirname(dirname(dirname(__DIR__))) . DS;
+			self::$rootFolder = APP . DS;
 		}
 
 		$classpath = self::$rootFolder . (empty($plugin) ? '' : 'Plugin' . DS . $plugin . DS) . 'Console' . DS . 'Command' . DS . $model . '.php';


### PR DESCRIPTION
in bootstrap.php it's possible to specify alternate path for plugin installation (especially when installed via composer)... 
if one uses App::build() for this purpose as described here:
http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#adding-paths-for-app-to-find-packages-in

the root folder won't be determined correctly. using "APP" constant is safer. 
