### PR TITLE
[Cake-2] Prevent sending signals to PIDs not originating from the current host

### DIFF
--- a/Console/Command/CakeResqueShell.php
+++ b/Console/Command/CakeResqueShell.php
@@ -842,10 +842,21 @@ class CakeResqueShell extends Shell {
 				$workerIndex = range(1, count($workers));
 			}
 
+			if (function_exists('gethostname')) {
+				$thisHostname = gethostname();
+			} else {
+				$thisHostname = php_uname('n');
+			}
+
 			foreach ($workerIndex as $index) {
 				$worker = $workers[$index - 1];
 
 				list($hostname, $pid, $queue) = explode(':', (string)$worker);
+
+				if ($hostname !== $thisHostname) {
+					continue;
+				}
+
 				if (Configure::read('CakeResque.Scheduler.enabled') === true && $ResqueStatus->isSchedulerWorker($worker)) {
 					if ($schedulerWorkerAction !== null) {
 						$schedulerWorkerAction($worker);


### PR DESCRIPTION
## Summary
When using multiple server to run workers, the `CakeResqueShell` understands that the name pattern contains the hostname but does not respect it when sending signals to the PIDs.

This will lead to wrong processes receiving the kill signal. This PR prevents this by simply ignoring those workers.

### Note
Although I created this PR in 2015, I updated it recently because I missed that it was against the master branch, which is already switched to CakePHP3 but I need this change for CakePHP2!

### Links
- Requires https://github.com/wa0x6e/ResqueStatus/pull/9